### PR TITLE
Fixed plot bathy kalman step

### DIFF
--- a/plotBathyKalmanStep.m
+++ b/plotBathyKalmanStep.m
@@ -42,7 +42,6 @@ title('Prior Err')
 h=colorbar('peer', gca); set( h, 'ydir', 'rev' ); 
 foo = get( h, 'yticklabel' );
 foo = strrep(foo,'-','');
-foo = num2str( abs(str2num(char(foo))), '%.1f' );
 set( h, 'yticklabel', foo );
 set( get(h,'title'), 'string', '(m)' );
 
@@ -55,7 +54,6 @@ title('Obs Err')
 h=colorbar('peer', gca); set( h, 'ydir', 'rev' ); 
 foo = get( h, 'yticklabel' );
 foo = strrep(foo,'-','');
-foo = num2str( abs(str2num(foo)), '%.1f' );
 set( h, 'yticklabel', foo );
 set( get(h,'title'), 'string', '(m)' );
 
@@ -67,7 +65,7 @@ xlabel('x (Relative m)'); ylabel('y (Relative m)');
 title('K')
 h=colorbar('peer', gca);  
 foo = get( h, 'yticklabel' );
-foo = num2str( abs(str2num(foo)), '%.1f' );
+foo = strrep(foo,'-','');
 set( h, 'yticklabel', foo );
 
 %

--- a/plotBathyKalmanStep.m
+++ b/plotBathyKalmanStep.m
@@ -41,7 +41,8 @@ xlabel('x (Relative m)'); ylabel('y (Relative m)');
 title('Prior Err')
 h=colorbar('peer', gca); set( h, 'ydir', 'rev' ); 
 foo = get( h, 'yticklabel' );
-foo = num2str( abs(str2num(foo)), '%.1f' );
+foo = strrep(foo,'-','');
+foo = num2str( abs(str2num(char(foo))), '%.1f' );
 set( h, 'yticklabel', foo );
 set( get(h,'title'), 'string', '(m)' );
 
@@ -53,6 +54,7 @@ xlabel('x (Relative m)'); ylabel('y (Relative m)');
 title('Obs Err')
 h=colorbar('peer', gca); set( h, 'ydir', 'rev' ); 
 foo = get( h, 'yticklabel' );
+foo = strrep(foo,'-','');
 foo = num2str( abs(str2num(foo)), '%.1f' );
 set( h, 'yticklabel', foo );
 set( get(h,'title'), 'string', '(m)' );


### PR DESCRIPTION
Edited lines that broke in versions of Matlab after 2014b because ylabels in newer versions are stored as cell array and not character arrays.