### PR TITLE
fix plotStackAndPhaseMaps for recent matlabs

### DIFF
--- a/plotStacksAndPhaseMaps.m
+++ b/plotStacksAndPhaseMaps.m
@@ -38,14 +38,19 @@ fB = params.fB;
 nf = length(fB);
 nCols = ceil(sqrt(nf));     % chose a reasonable number of rows and cols for display
 nRows = ceil(nf/nCols);
-figure(11); set(gcf, 'name', 'Phase Maps'); clf;
+figure(11); set(gcf, 'name', 'Phase Maps'); clf; colormap('jet');
 for i = 1:nf
-    ind = find(f<=fB(i),1,'last');
-    subplot(nRows, nCols, i); hold on
-    h=scatter3(xyz(:,1),xyz(:,2),angle(G(ind,:)),18,angle(G(ind,:)),'filled');
-    xlabel('x (m)'); ylabel('y (m)'); axis equal, caxis([-pi pi]);
+    ind = find(abs(f-fB(i)) == min(abs(f-fB(i))));
+    subplot(nRows, nCols, i,'FontSize',7); hold on
+    h=scatter(xyz(:,1),xyz(:,2),3,angle(G(ind,:)),'filled');
+    xlabel('x (m)'); 
+    ylabel('y (m)'); 
+    axis equal;
+    caxis([-pi pi]);
     axis ([ min(xyz(:,1)) max(xyz(:,1)) min(xyz(:,2)) max(xyz(:,2))]);
-    view(2); title(['freq = ' num2str(fB(i),'%0.3g') ' Hz']); grid on
+    view(2); 
+    title(['f = ' num2str(fB(i),'%0.3g') ' Hz'],'FontWeight','normal','FontSize',9); 
+    grid on
 end
 
 % figure(3); set(gcf,'name', 'Phase Transects'); clf;
@@ -60,7 +65,7 @@ end
 %     title(['freq = ' num2str(fs(i),'%0.3g') ' Hz']); grid on
 % end
 
-
+%
 %
 %   Copyright (C) 2017  Coastal Imaging Research Network
 %                       and Oregon State University


### PR DESCRIPTION
Issue observed at boot camp -- phase plots were unusable in more recent versions of matlab. matlab 2014b changed some basic graphics stuff.

forced colormap from new default of palula back to old default of 'jet'. 
forced title font to smaller, normal font instead of larger bold.
changed font size of tic labels
changed scatter3 to scatter, size of circles from 18 to 3. 

works in 2010a, 2013b, 2017a. Subplots do not resize in testing on 2016a, reason unknown. Appears to be bug in 2016a using software openGL renderer. I find nothing relevant in the release notes for 2016b or 2017a. 
