### PR TITLE
Wrap alpha estimates and out-of-bounds quality control to the range [-pi pi)

### DIFF
--- a/csmInvertKAlpha.m
+++ b/csmInvertKAlpha.m
@@ -141,7 +141,7 @@ for i = 1:nKeep         % frequency loop
             alphaOffsetWrapped = mod((kAlphaPhi(2)-seedAlpha)+pi,2*pi)-pi;
             % then check if k & alpha are outside acceptable limits
             if ((kAlphaPhi(1)<LB_UB(1,1)) || (kAlphaPhi(1)>LB_UB(2,1)) ...
-                    || abs(alphaOffsetWrapped > maxAlphaOffset))
+                    || abs(alphaOffsetWrapped) > maxAlphaOffset)
                 error;
             end
             % if good, then wrap alpha to a standard range, [-pi, pi)

--- a/csmInvertKAlpha.m
+++ b/csmInvertKAlpha.m
@@ -38,6 +38,7 @@ clear fDependent
 g=9.81;                         % 'g'
 minNeededPixels = 6;            % to avoid edge anomalies
 minLFraction = 0.5;             % min fract of wavelength to span
+maxAlphaOffset = pi/2;          % max radian distance from expected wave direction
 
 OPTIONS = statset('nlinfit');   % fit options
 OPTIONS.MaxIter = 50;
@@ -65,7 +66,7 @@ for i = 1: length(fB)
     C(:,:,i) = G(id,:)'*G(id,:) / length(id);   % pos 2nd leads 1st.
 end
 
-% create the coherence squared for all the potential frequence bands
+% create the coherence squared for all the potential frequency bands
 coh2 = squeeze(sum(sum(abs(C)))/(size(xyz,1)*(size(xyz,1)-1)));
 [~, coh2Sortid] = sort(coh2, 1, 'descend');  % sort by coh2
 fs = fB(coh2Sortid(1:nKeep));         % keep only the nKeep most coherent
@@ -105,7 +106,7 @@ for i = 1:nKeep         % frequency loop
     kmin = (2*pi*fs(i))^2/g; % smallest  and largest wavenumber
     kmax = 2*pi*fs(i)/sqrt(g*params.MINDEPTH); 
     LExpect = minLFraction*4*pi/(kmin+kmax);     % expected scale from mean k.
-    LB_UB = [kmin seedAlpha-pi/2;kmax seedAlpha+pi/2];
+    LB_UB = [kmin; kmax];
     OPTIONS.TolX = min([kmin/1000,pi/180/1000]); % min([kmin/100,pi/180/10]);
     statset(OPTIONS);
     warning off stats:nlinfit:IterationLimitExceeded
@@ -135,12 +136,16 @@ for i = 1:nKeep         % frequency loop
             kAlphaPhiInit = findKAlphaPhiInit(v, xy, LB_UB, params);
             [kAlphaPhi,resid,jacob] = nlinfit([xy w], [real(v); imag(v)],...
                            'predictCSM',kAlphaPhiInit, OPTIONS);
-            
-            % check if outside acceptable limits
+                        
+            % first wrap alpha offset from seed to the range [-pi, pi)
+            alphaOffsetWrapped = mod((kAlphaPhi(2)-seedAlpha)+pi,2*pi)-pi;
+            % then check if k & alpha are outside acceptable limits
             if ((kAlphaPhi(1)<LB_UB(1,1)) || (kAlphaPhi(1)>LB_UB(2,1)) ...
-                    || (kAlphaPhi(2)<LB_UB(1,2)) || (kAlphaPhi(2)>LB_UB(2,2)))
+                    || abs(alphaOffsetWrapped > maxAlphaOffset))
                 error;
             end
+            % if good, then wrap alpha to a standard range, [-pi, pi)
+            kAlphaPhi(2) = mod(kAlphaPhi(2)+pi,2*pi)-pi;
             
             % get predictions then skill
             vPred = predictCSM(kAlphaPhi, [xy abs(v)]);


### PR DESCRIPTION
This fix wraps the difference between estimated and seed alpha to the range [-pi pi) before applying out-of-bounds quality control. The fix is needed because alpha estimates are initialized (in kAlphaPhiInit.m) to the range [-2pi 0] and estimated (via the least squares fit in csmInvertKAlpha.m) in an unwrapped range, but then good alpha estimates are assumed to all lie within pi/2 radians of the seed. This fix also wraps the alpha estimates themselves so that the estimates lie in a standard, wrapped range.