### PR TITLE
Mpalmsten nlinfit update

### DIFF
--- a/LMFnlsq.m
+++ b/LMFnlsq.m
@@ -1,0 +1,551 @@
+function [xf, SS, cnt, res, XY,A,r] = LMFnlsq(varargin)
+% LMFNLSQ   Solve one or a set of (over)determined nonlinear equations
+% in the least squares sense
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% A solution is obtained by a Fletcher's version of the Levenberg-Maquardt
+% algoritm for minimization of a sum of squares of equation residuals.
+% The main domain of LMFnlsq applications is in curve fitting during
+% processing of experimental data.
+%
+% [Xf, Ssq, CNT, Res, XY] = LMFnlsq(FUN,Xo,t,yDat,Options)
+% ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+% Input arguments:
+% FUN     is a function handle or a function M-file name (string) that
+%         evaluates m-vector of equation residuals. Residuals are defined
+%         as   res = FUN(t) - yDat,  where y is m-vector of given values.
+% Xo      is n-vector of initial guesses of solution, unknown parameters,
+%         n >= 1;
+% t       independent variable for Fun(t)
+% yDat    data, dependent variable
+% Options is an optional set of Name/Value pairs of control parameters
+%         of the algorithm. It may also be preset by calling:
+%         Options = LMFnlsq; %   for setting default values for Options,
+%         Options = LMFnlsq('default');  or by a set of Name/Value pairs:
+%         Options = LMFnlsq('Name',Value, ... ), or updating the Options
+%                   set by calling
+%         Options = LMFnlsq(Options,'Name',Value, ...).
+%
+%    Name   Values {default}         Description
+% 'Display'      {0}        Display control
+%                             0   no display
+%                             k   display initial and each k-th iteration;
+% 'Printf'    name|handle   Function for displaying of results; {@printit}
+% 'Jacobian'  name|handle   Jacobian matrix function; {@finjac}
+% 'FunTol'      {1e-7}      norm(FUN(x),1) stopping tolerance;
+% 'XTol'                    Stopping tolerance:
+%               {1e-7}        scalar for equal delta x_i, or
+%                             vector for particular delta x_i;
+% 'MaxIter'     {100}       Maximum number of iterations;
+% 'ScaleD'                  Scale control:
+%               value         D = eye(m)*value;
+%               vector        D = diag(vector);
+%                {[]}         D(k,k) = JJ(k,k) for JJ(k,k)>0, or
+%                                    = 1 otherwise,
+%                                      where JJ = J.'*J
+% 'Trace'        {0}        Tracing control:
+%                             0 = don't save iteration results x^(k)
+%                             nonzero = save iteration results x^(k)
+% 'Lambda'       {0}        Initial value of parameter lambda
+%
+% A user may supply his own functions for building Jacobian matrix and for
+% displaying intermediate results (corresponding to 'Jacobian' and
+% 'Printf' options respectively).
+% Not defined fields of the Options structure are filled by default values.
+%
+% Output Arguments:
+%   Xf    final solution approximation
+%   Ssq   sum of squares of residuals
+%   Cnt     >0          count of iterations
+%           -MaxIter,   no converge in MaxIter iterations
+%   Res   number of calls of FUN and Jacobian matrix
+%   XY    points of intermediate results in iterations
+%
+% Forms of function callings:
+%   LMFnlsq                             %   Display help to LMFnlsq
+%   Options = LMFnlsq;                  %   Settings of Options
+%   Options = LMFnlsq('default');       %   The same as  Options = LMFnlsq;
+%   Options = LMFnlsq(Name1,Value1,Name2,Value2,…);
+%   Options = LMFnlsq(Options,Name1,Value1,Name2,Value2,…);
+%   x = LMFnlsq(Eqns,x0);               %   Solution with default Options
+%   x = LMFnlsq(Eqns,x0,Options);       %   Solution with preset Options
+%   x = LMFnlsq(Eqns,x0,Name1,Value1,Name2,Value2,…);% W/O preset Options
+%   [x,ssq] = LMFnlsq(Eqns,x0,…);       %   with output of sum of squares
+%   [x,ssq,cnt] = LMFnlsq(Eqns,x0,…);   %   with iterations count
+%   [x,ssq,cnt,nfJ,xy,A,r] = LMFnlsq(Eqns,x0,…); 
+% 
+% Note:
+% It is recommended to modify slightly the call of LMFnlsq for improvement
+% of reliability of results and stability of the iteration process, namely
+% if range of values of x's be large:
+%   x0 = vector of user-defined initial guess;
+%   x0 = x0(:);
+%   x  = LMFnlsq(Eqns,size(length(x0)), ...);
+% This form has been used for testing problems of NIST. solution of one of
+% them, BoxBOD, is included in the file BoxBOD.zip.
+%
+%% Example 1:
+% The general Rosenbrock's function has the form of a sum of squares:
+%    f(x) = 100(x(2)-x(1)^2)^2 + (1-x(1))^2
+% Optimum solution gives f(x)=0 for x(1)=x(2)=1. Function f(x) can be
+% expressed in the form
+%    f(x) = f1(x)^2 =f2(x)^2,
+% where f1(x) = 10(x(2)-x(1)^2) and f2(x) = 1-x(1).
+% Values of the functions f1(x) and f2(x) can be used as residuals.
+% LMFnlsq finds the solution of this problem in 17 iterations with default
+% settings. The function FUN has the form of named function
+%
+%   function r = rosen(x)
+%% ROSEN   Rosenbrock valey residuals
+%   r = [ 10*(x(2)-x(1)^2)      %   first part,  f1(x)
+%         1-x(1)                %   second part, f2(x)
+%       ];
+% or an anonymous function
+%   rosen = @(x) [10*(x(2)-x(1)^2); 1-x(1)];
+%
+%% Example 2:
+% Even that the function LMFnlsq is devoted for solving unconstrained
+% problems, sometimes it is possible to solve also constrained problems,
+% eg.:
+% Find the least squares solution of the Rosenbrock's valey inside a circle
+% of the unit diameter centered at the origin. In this case, it is necessary 
+% to build third function, a penalty, which is zero inside the circle and 
+% increasing outside it. This property has, say, the next function:
+%    f3(x) = sqrt(x(1)^2 + x(2)^2) - d, where d is a distance from the 
+% circle border. Its implementation using named function has the form
+%   function r = rosen(x)
+%% ROSEN   Rosenbrock valey with a constraint
+%   d = sqrt(x(1)^2+x(2)^2)-.5; %   distance from r=0.5
+%   r = [ 10*(x(2)-x(1)^2)      %   first part,  f1(x)
+%         1-x(1)                %   second part, f2(x)
+%         (d>0)*d*w             %   penalty outside the feasible domain
+%       ];                      %   w = 1000 is a weight of the condition
+% or when anonymous functions are prefered
+%    d     = @(x) sqrt(x'*x)-.5; %   A distance from the radius r=0.5
+%    rosen = @(x) [10*(x(2)-x(1)^2); 1-x(1); (d(x)>0)*d(x)*1000];
+%
+% The solution is obtained in all cases by setting (say) FUN='rosen' in the
+% first case, or FUN=rosen in the second one, and by calling
+%    [x,ssq,cnt,loops]=LMFnlsq(FUN,[-1.2,1],'Display',1,'MaxIter',50)
+% yielding results
+%    x=[0.45565; 0.20587],  |x|=0.5000,  ssq=0.29662,  cnt=43,  loops=58
+% Exactly the same result is obtained, if analytical formula for the
+% Jacobian matrix J is supplied. In case of anonymous function, the form of
+% J may be defined as
+%    jacob = @(x) [-20*x(1),10;-1,0;(d(x)>0)*1000/(d(x)+.5)*[x(1),x(2)]];
+% and a minimum call is
+%    [x,ssq,cnt,loop]=LMFnlsq('rosen',[-1.2,1],'Jacobian',jacob);
+% Since the formula for J is more complicated than that for the function in
+% this case, the total time is shorter for evaluating J from finite
+% differences, what is default.
+%
+%% Example 3 - Curve fit:
+% For curve fit, see the accompanying script LMFnlsqtest and a document
+% LMFnlsq.pdf.
+%
+% Reference:
+% Fletcher, R., (1971): A Modified Marquardt Subroutine for Nonlinear Least
+% Squares. Rpt. AERE-R 6799, Harwell
+
+% M. Balda,
+% Institute of Thermomechanics,
+% Academy of Sciences of The Czech Republic,
+% balda AT cdm DOT cas DOT cz
+% miroslav AT balda DOT cz
+% 
+% 2007-07-02    a bit modified function LMFsolve
+% 2007-10-08    Formal changes, improved description
+% 2007-11-01    Completely reconstructed into LMFnlsq, new optional
+%               parameters, improved stability
+% 2007-12-06    Widened Option setting, improved help and description
+% 2008-07-08    Complemented part for evaluation of Jacobian matrix from 
+%               an analytical formula. Small changes have been made in 
+%               description and comments.
+% 2009-01-20    Implemented new subfunction for printing intermediate
+%               results, and introduced a slight modification both of the 
+%               function and a testing script code. The pdf-file of
+%               description has been complemented by a short theoretical
+%               description of the LMF method.
+% 2011-12-15 v.2.0 Improved description (help), improved printout
+% 2012-02-18 v.2.1 Repaired a small bug in vector XTol setting.
+% 2018-05-31    M.Palmsten, NRL, edited outputs to include the residual, r,
+%               and the A-matrix
+% 2018-06-01    M. Palmsten, NRL, edited inputs to include dependent and
+%               independent data for curve fitting, line 244
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+if nargin==0 && nargout==0, help LMFnlsq, return, end     %   Display help
+
+%   Options = LMFnlsq;
+%   Options = LMFnlsq('default');
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%       Default Options
+if nargin==0 || (nargin==1 && strcmpi('default',varargin(1)))
+   xf.Display  = 0;         %   no print of iterations
+   xf.Jacobian = 'finjac';  %   finite difference Jacobian approximation
+   xf.MaxIter  = 0;         %   maximum number of iterations allowed
+   xf.ScaleD   = [];        %   automatic scaling by D = diag(diag(J'*J))
+   xf.FunTol   = 1e-7;      %   tolerace for final function value
+   xf.XTol     = 1e-7;      %   tolerance on difference of x-solutions
+   xf.Printf   = 'printit'; %   disply intermediate results
+   xf.Trace    = 0;         %   don't save  intermediate results
+   xf.Lambda   = 0;         %   start with Newton iteration
+   return
+
+   
+%   Options = LMFnlsq(Options,name,value,...);
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%       Updating Options
+elseif isstruct(varargin{1}) % Options=LMFnlsq(Options,'Name','Value',...)
+    if ~isfield(varargin{1},'Jacobian')
+        error('Options Structure not Correct for LMFnlsq.')
+    end
+    xf=varargin{1};          %   Options
+    for i=2:2:nargin-1
+        name=varargin{i};    %   option to be updated
+        if ~ischar(name)
+            error('Parameter Names Must be Strings.')
+        end
+        name=lower(name(isletter(name)));
+        value=varargin{i+1}; %   value of the option
+        if strncmp(name,'d',1), xf.Display  = value;
+        elseif strncmp(name,'f',1), xf.FunTol   = value;
+        elseif strncmp(name,'x',1), xf.XTol     = value;
+        elseif strncmp(name,'j',1), xf.Jacobian = value;
+        elseif strncmp(name,'m',1), xf.MaxIter  = value;
+        elseif strncmp(name,'s',1), xf.ScaleD   = value;
+        elseif strncmp(name,'p',1), xf.Printf   = value;
+        elseif strncmp(name,'t',1), xf.Trace    = value;
+        elseif strncmp(name,'l',1), xf.Lambda   = value;
+        else   disp(['Unknown Parameter Name --> ' name])
+        end
+    end
+    return
+
+%   Options = LMFnlsq(name,value,...);
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%       Pairs of Options
+elseif ischar(varargin{1})  % check for Options=LMFnlsq('Name',Value,...)
+   Pnames=char('display','funtol','xtol','jacobian','maxiter','scaled',...
+               'printf','trace','lambda');
+   if strncmpi(varargin{1},Pnames,length(varargin{1}))
+      xf=LMFnlsq('default');  % get default values
+      xf=LMFnlsq(xf,varargin{:});
+      return
+   end
+end
+
+%   [Xf,Ssq,CNT,Res,XY] = LMFnlsq(FUN,Xo,Options);
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%               OPTIONS
+%               *******
+FUN=varargin{1};            %   function handle
+if ~(isvarname(FUN) || isa(FUN,'function_handle'))
+   error('FUN Must be a Function Handle or M-file Name.')
+end
+xc=varargin{2};             %   Xo
+t = varargin{3}; % independent variable in curve fit
+yDat = varargin{4}; % data for curve fit
+
+if ~exist('options','var')
+    options = LMFnlsq('default');
+end
+if nargin>3                 %   OPTIONS
+    if isstruct(varargin{5})
+        options=varargin{5};
+    else
+        for i=5:2:size(varargin,2)-1
+            options=LMFnlsq(options, varargin{i},varargin{i+1});
+        end
+    end
+else
+    if ~exist('options','var')
+        options = LMFnlsq('default');
+    end
+end
+
+
+
+
+%               INITIATION OF SOLUTION
+%               **********************
+x = xc(:);
+n = length(x);
+epsx = options.XTol(:);
+le = length(epsx);
+if le==1
+    epsx=epsx*ones(n,1);
+elseif le~=n
+    error(['Dimensions of vector epsx ',num2str(le),'~=',num2str(lx)]);
+end
+epsf  = options.FunTol(:);
+ipr   = options.Display;
+JAC   = options.Jacobian;
+maxit = options.MaxIter;    %   maximum permitted number of iterations
+if maxit==0, maxit=100*n; end
+printf= options.Printf;
+
+r = feval(FUN,x,t,yDat);
+[A,v] = getAv(FUN,JAC,x,t,yDat,r,epsx);
+%~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SS = r'*r;
+res= 1;
+cnt=0;
+trcXY = options.Trace;      %   iteration tracing
+if trcXY
+    XY = zeros(n,maxit);
+    XY(:,1) = x;
+else
+    XY = [];
+end
+
+D = options.ScaleD(:);      %   CONSTANT SCALE CONTROL D
+if isempty(D)
+    D=diag(A);              %   automatic scaling
+else
+    ld=length(D);
+    if ld==1
+        D=abs(D)*ones(n,1); %   scalar of unique scaling
+    elseif ld~=n
+        error(['wrong number of scales D, lD = ',num2str(ld)])
+    end
+end
+D(D<=0)=1;
+T = sqrt(D);
+
+Rlo=0.25;
+Rhi=0.75;
+l=options.Lambda;       lc=1;
+feval(printf,ipr,-1);       %   Table header
+dx = zeros(n,1);
+
+%               SOLUTION
+%               ********    MAIN ITERATION CYCLE
+while 1 %                   ********************
+    feval(printf,ipr,cnt,res,SS,x,dx,l,lc)
+    cnt = cnt+1;
+    if trcXY, XY(:,cnt+1)=x; end
+    d = diag(A);
+    s = zeros(n,1);
+%                           INTERNAL CYCLE
+    while 1 %               ~~~~~~~~~~~~~~
+        while 1
+            UA = triu(A,1);
+            A = UA'+UA+diag(d+l*D);
+            [U,p] = chol(A);%UA,A,U,p,D,d,l, pause   Choleski decomposition
+            %~~~~~~~~~~~~~~~
+            if p==0, break, end
+            l = 2*l;
+            if l==0, l=1; end
+        end
+        dx = U\(U'\v);
+        vw = dx'*v;
+        fin = -1;
+        if vw<=0, break, end        %   The END
+
+        for i=1:n
+            z = d(i)*dx(i);
+            if i>1, z=A(i,1:i-1)*dx(1:i-1)+z; end
+            if i<n, z=A(i+1:n,i)'*dx(i+1:n)+z; end
+            s(i) = 2*v(i)-z;
+        end
+        dq = s'*dx;
+        s  = x-dx;
+        rd = feval(FUN,s,t,yDat);
+%            ~~~~~~~~~~~~
+        res = res+1;
+        SSP = rd'*rd;
+        dS  = SS-SSP;
+        fin = 1;
+        if all((abs(dx)-epsx)<=0) || res>=maxit || abs(dS)<=epsf
+            break                   %   The END
+        end
+        fin=0;
+        if dS>=Rlo*dq, break, end
+        A = U;
+        y = .5;
+        z = 2*vw-dS;
+        if z>0, y=vw/z; end
+        if y>.5, y=.5; end
+        if y<.1, y=.1; end
+        if l==0
+            y = 2*y;
+            for i = 1:n
+                A(i,i) = 1/A(i,i);
+            end
+            for i = 2:n
+                ii = i-1;
+                for j= 1:ii
+                    A(j,i) = -A(j,j:ii)*A(j:ii,i).*A(i,i);
+                end
+            end
+            for i = 1:n
+                for j= i:n
+                    A(i,j) = abs(A(i,j:n)*A(j,j:n)');
+                end
+            end
+            l  = 0;
+            tr = diag(A)'*D;
+            for i = 1:n
+                z = A(1:i,i)'*T(1:i)+z;
+                if i<n
+                    ii = i+1;
+                    z  = A(i,ii:n)*T(ii:n)+z;
+                end
+                z = z*T(i);
+                if z>l, l=z; end
+            end
+            if tr<l, l=tr; end
+            l  = 1/l;
+            lc = l;
+        end
+        l = l/y;
+        if dS>0, dS=-1e300; break, end
+    end %  while            INTERNAL CYCLE LOOP
+%                           ~~~~~~~~~~~~~~~~~~~
+
+    if fin, break, end
+    if dS>Rhi*dq
+        l=l/2;
+        if l<lc, l=0; end
+    end
+    SS=SSP;  x=s;  r=rd;
+    [A,v] = getAv(FUN,JAC,x,t,yDat,r,epsx);
+    %~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+end % while                 MAIN ITERATION CYCLE LOOP
+%                           *************************
+
+if fin>0
+    if dS>0
+        SS = SSP;
+        x  = s;
+    end
+end
+if ipr~=0
+    disp(' ');
+    feval(printf,sign(ipr),cnt,res,SS,x,dx,l,lc)
+end
+xf = x;
+if trcXY, XY(:,cnt+2)=x; end
+XY(:,cnt+3:end) = [];
+if res>=maxit, cnt=-maxit; end
+return
+%end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+function [A,v] = getAv(FUN,JAC,x,t,yDat,r,epsx)
+%        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  Calculate A, v, r
+if isa(JAC,'function_handle')
+    J = JAC(x);
+else
+    J = feval(JAC,FUN,r,x,t,yDat,epsx);
+end
+A = J'*J;
+v = J'*r;
+%end % getAv
+% --------------------------------------------------------------------
+
+function J = finjac(FUN,r,x,t,yDat,epsx)
+%~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  numerical approximation to Jacobi matrix
+rc = r(:);
+lx = length(x);
+J  = zeros(length(r),lx);
+for k = 1:lx
+    dx = .25*epsx(k);
+    if dx==0, dx=eps; end
+    xd = x;
+    xd(k) = xd(k)+dx;
+    rd = feval(FUN,xd,t,yDat);
+%   ~~~~~~~~~~~~~~~~~~~
+    J(:,k)=((rd(:)-rc)/dx);
+end
+%end % finjac
+% --------------------------------------------------------------------
+
+function printit(ipr,cnt,res,SS,x,dx,l,lc)
+%        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  Printing of intermediate results
+%  ipr <  0  do not print lambda columns
+%      =  0  do not print at all
+%      >  0  print every (ipr)th iteration
+%  cnt = -1  print out the header
+%         0  print out second row of results
+%        >0  print out first row of results
+if ipr~=0
+   if cnt<0                 %   table header
+      disp('')
+      nch = 50+(ipr>0)*25;
+      disp(char('*'*ones(1,nch)))
+      fprintf('  itr  nfJ   SUM(r^2)        x           dx');
+      if ipr>0
+          fprintf('           l           lc');
+      end
+      fprintf('\n');
+      disp(char('*'*ones(1,nch)))
+      disp('')
+   else                     %   iteration output
+      if rem(cnt,ipr)==0
+          f='%12.4e ';
+          if ipr>0
+             fprintf(['%4.0f %4.0f ' f f f f f '\n'],...
+                 cnt,res,SS, x(1),dx(1),l,lc);
+          else
+             fprintf(['%4.0f %4.0f ' f f f '\n'],...
+                 cnt,res,SS, x(1),dx(1));
+          end
+          for k=2:length(x)
+             fprintf([blanks(23) f f '\n'],x(k),dx(k));
+          end
+      end
+   end
+end
+%end % printit
+%end % LMFnlsq
+
+% Copyright (c) 2007, Miroslav Balda
+% All rights reserved.
+% 
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions are
+% met:
+% 
+%     * Redistributions of source code must retain the above copyright
+%       notice, this list of conditions and the following disclaimer.
+%     * Redistributions in binary form must reproduce the above copyright
+%       notice, this list of conditions and the following disclaimer in
+%       the documentation and/or other materials provided with the distribution
+% 
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+% AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+% LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+% CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+% SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+% INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+% CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+% ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+%
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%

--- a/aerielle.m
+++ b/aerielle.m
@@ -1,0 +1,64 @@
+%%% Site-specific Inputs
+params.stationStr = 'aerielle';
+params.dxm = 10;                    % analysis domain spacing in x
+params.dym = 25;                    % analysis domain spacing in y
+params.xyMinMax = [80 500 500 700];   % min, max of x, then y
+                                    % default to [] for cBathy to choose
+params.tideFunction = 'cBathyTide';  % tide level function for evel
+
+%%%%%%%   Power user settings from here down   %%%%%%%
+params.MINDEPTH = 0.25;             % for initialization and final QC
+params.minValsForBathyEst = 4;      % min num f-k pairs for bathy est.
+
+params.QTOL = 0.5;                  % reject skill below this in csm
+params.minLam = 10;                 % min normalized eigenvalue to proceed
+params.Lx = 2*params.dxm;           % tomographic domain smoothing
+params.Ly = 2*params.dym;           % 
+params.kappa0 = 2;                  % increase in smoothing at outer xm
+params.DECIMATE = 1;                % decimate pixels to reduce work load.
+params.maxNPix = 80;                % max num pixels per tile (decimate excess)
+
+% f-domain etc.
+params.fB = [1/18: 1/50: 1/4];		% frequencies for analysis (~40 dof)
+params.nKeep = 4;                   % number of frequencies to keep
+
+% debugging options
+params.debug.production = 0;
+params.debug.DOPLOTSTACKANDPHASEMAPS = 1;  % top level debug of phase
+params.debug.DOSHOWPROGRESS = 1;		  % show progress of tiles
+params.debug.DOPLOTPHASETILE = 1;		  % observed and EOF results per pt
+params.debug.TRANSECTX = 200;		  % for plotStacksAndPhaseMaps
+params.debug.TRANSECTY = 600;		  % for plotStacksAndPhaseMaps
+
+% default offshore wave angle.  For search seeds.
+params.offshoreRadCCWFromx = 0;
+
+% choose method for non-linear fit
+params.nlinfit = 0; % flag, 0 = use LMFnlsq.m to do non-linear fitting
+                    %       1 = use Matlab Statistics and computer vision
+                    %       toolbox nlinfit.m 
+
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%
+

--- a/analyzeSingleBathyRunAerielleNotCIL.m
+++ b/analyzeSingleBathyRunAerielleNotCIL.m
@@ -1,0 +1,47 @@
+function bathy = analyzeSingleBathyRunAerielleNotCIL(stackPnStr, stationStr)
+%
+%  bathy = analyzeSingleBathyRunNotCIL(stackPnStr, stationStr)
+%
+%  simple run of analyzeBathyCollect for a single stack.  Useful for
+%  debugging.  Assumes stackPnStr is a loadable file which contains
+%  variables 
+%       epoch   - epoch times for each row in stack, Nt by 1
+%       xyz     - xyz locations for each column in stack, Nxyz by 1
+%       data    - Nt by Nxyz matrix of cBathy stack data
+%
+%   stationStr is the name of the station, for example 'argus02b' or
+%   whatever naming convention you chose.  This name MUST correspond to a
+%   callable m-file that creates the params structure that contains all of
+%   the processing inputs.
+
+eval(stationStr)        % creates the params structure.
+load(stackPnStr)           % load xyz, t, data
+bathy.epoch = num2str(matlab2Epoch(stack.dn(1)')); % convert to epoch time
+bathy.sName = stackPnStr;
+bathy.params = params;
+bathy = analyzeBathyCollect(stack.xyzAll, matlab2Epoch(stack.dn'), stack.data, bathy);
+
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%
+

--- a/argus02a.m
+++ b/argus02a.m
@@ -33,6 +33,11 @@ params.debug.TRANSECTY = 900;		  % for plotStacksAndPhaseMaps
 % default offshore wave angle.  For search seeds.
 params.offshoreRadCCWFromx = 0;
 
+% choose method for non-linear fit
+params.nlinfit = 0; % flag, 0 = use Richie Slocum's lsr to do non-linear fitting
+                    %       1 = use Matlab Statistics and computer vision
+                    %       toolbox nlinfit.m 
+
 %
 %   Copyright (C) 2017  Coastal Imaging Research Network
 %                       and Oregon State University

--- a/argus02a.m
+++ b/argus02a.m
@@ -34,7 +34,7 @@ params.debug.TRANSECTY = 900;		  % for plotStacksAndPhaseMaps
 params.offshoreRadCCWFromx = 0;
 
 % choose method for non-linear fit
-params.nlinfit = 0; % flag, 0 = use Richie Slocum's lsr to do non-linear fitting
+params.nlinfit = 0; % flag, 0 = use LMFnlsq.m to do non-linear fitting
                     %       1 = use Matlab Statistics and computer vision
                     %       toolbox nlinfit.m 
 

--- a/argus02b.m
+++ b/argus02b.m
@@ -32,6 +32,10 @@ params.debug.TRANSECTY = 900;		  % for plotStacksAndPhaseMaps
 % default offshore wave angle.  For search seeds.
 params.offshoreRadCCWFromx = 0;
 
+% choose method for non-linear fit
+params.nlinfit = 0; % flag, 0 = use LMFnlsq.m to do non-linear fitting
+                    %       1 = use Matlab Statistics and computer vision
+                    %       toolbox nlinfit.m 
 %
 % Copyright by Oregon State University, 2011
 % Developed through collaborative effort of the Argus Users Group

--- a/bathyCI.m
+++ b/bathyCI.m
@@ -1,4 +1,4 @@
-function bathyErr = bathyCI(resid,J,w)
+function bathyErr = bathyCI(resid,J,w,flag)
 % 
 %   bathyErr = bathyCI(resid,J,w)
 %
@@ -9,8 +9,10 @@ function bathyErr = bathyCI(resid,J,w)
 %
 %  Inputs:
 %   resid   - Nx1 vector or prediction residuals from k-estimates
-%   J       - Jacobian (both these are from nlinfit)
+%   J       - if flag = 1,Jacobian (both these are from nlinfit)
+%           - if flag = 0, expected input is J'*J, from LMFnlsq.m
 %   w       - weights used in weighted nlinfit
+%   flag    - 1 = use statistics toolbox, 0 = don't use stats toolbox
 %  Output:
 %   bathyErr - 95% confidence interval on depth estimate.
 %
@@ -22,18 +24,26 @@ alpha = 0.05;
 n = sum(w)/max(w);  % Holman kludge
 v = n-1;
 
-% Calculate covariance matrix
-[~,R] = qr(J,0);
-Rinv = R\eye(size(R));
-diag_info = sum(Rinv.*Rinv,2);
-
-rmse = norm(resid) / sqrt(v);
-se = sqrt(diag_info) * rmse;
-
-% Calculate bathyError from t-stats.
-bathyErr = se * tinv(1-alpha/2,v);
-
-
+if flag == 1 && ~isempty(ver('stats')) % use the stats toolbox if you have it
+    
+    % Calculate covariance matrix
+    [~,R] = qr(J,0);
+    Rinv = R\eye(size(R));
+    diag_info = sum(Rinv.*Rinv,2);
+    
+    rmse = norm(resid) / sqrt(v);
+    se = sqrt(diag_info) * rmse;
+    
+    % Calculate bathyError from t-stats.
+    bathyErr = se * tinv(1-alpha/2,v);
+    
+elseif flag || ~isempty(ver('stats')) % if you don't have the stats toolbox, or you don't want to use it
+    
+    rmse = norm(resid) / sqrt(v);
+    se = rmse*sqrt(diag(inv(J)));
+    bathyErr = se*tstat3( v, 1-alpha/2, 'inv' );
+    
+end
 %
 %   Copyright (C) 2017  Coastal Imaging Research Network
 %                       and Oregon State University

--- a/csmInvertKAlpha.m
+++ b/csmInvertKAlpha.m
@@ -31,9 +31,10 @@ function fDependent = ...
 % 09/01/11 - Holman rewrite to finally get rid of tiling and analyze a
 %   single location only
 % 12/05/11 - Holman major change to base on EOFs rather than direct from CSM
+% 5/19/2018  - Palmsten add option to use Richie Slocum's nonlinear fit
+% instead of nlinfit.m from Matlab Statistics and Machine Learning Toolbox
 
 %% %%  1. constants and parameters
-
 clear fDependent
 g=9.81;                         % 'g'
 minNeededPixels = 6;            % to avoid edge anomalies
@@ -133,8 +134,13 @@ for i = 1:nKeep         % frequency loop
         try
             % do nonlinear fit on surviving data
             kAlphaPhiInit = findKAlphaPhiInit(v, xy, LB_UB, params);
-            [kAlphaPhi,resid,jacob] = nlinfit([xy w], [real(v); imag(v)],...
-                           'predictCSM',kAlphaPhiInit, OPTIONS);
+            if params.nlinfit == 1 & ~isempty(ver('stats')) % use the stats toolbox if you have it
+                [kAlphaPhi,resid,jacob] = nlinfit([xy w], [real(v); imag(v)],...
+                    'predictCSM',kAlphaPhiInit, OPTIONS);
+            elseif params.nlinfit == 0 | ~isempty(ver('stats')) % if you don't have the stats toolbox, or you don't want to use it
+                [kAlphaPhi,ssq,cnt, res, XY,A,resid] = LMFnlsq('res',kAlphaPhiInit,[xy w], [real(v); imag(v)], 'Display',0);
+                kAlphaPhi = kAlphaPhi';
+            end
             
             % check if outside acceptable limits
             if ((kAlphaPhi(1)<LB_UB(1,1)) || (kAlphaPhi(1)>LB_UB(2,1)) ...
@@ -155,8 +161,15 @@ for i = 1:nKeep         % frequency loop
             end
 
             % get confidence limits
-            ex = nlparci(real(0*kAlphaPhi),resid,jacob); % get limits not bounds
-            ex = real(ex(:,2)); % get limit, not bounds
+            if params.nlinfit == 1 & ~isempty(ver('stats')) % use the stats toolbox if you have it
+                ex = nlparci(real(0*kAlphaPhi),resid,jacob); % get limits not bounds
+                ex = real(ex(:,2)); % get limit, not bounds
+             elseif params.nlinfit == 0 | ~isempty(ver('stats')) % if you don't have the stats toolbox, or you don't want to use it
+                DOF = size(v,1)*2-size(kAlphaPhi,2); % degrees of freedom
+                rmse = norm(resid) / sqrt(DOF);
+                %ex = sigma_p*tstat3( DOF, 1-0.025, 'inv' );
+                ex = rmse*sqrt(diag(inv(A)))*tstat3( DOF, 1-0.025, 'inv' );
+            end
         catch   % nlinfit failed with fatal errors, adding bogus
             kAlphaPhi = [nan nan nan];
             ex = kAlphaPhi;

--- a/democBathyUAV.m
+++ b/democBathyUAV.m
@@ -1,0 +1,60 @@
+% This is an example m-file to demonstrate how to run cBathy and display
+% results.  It uses a supplied example data set and does not make
+% assumptions about CIL conventions or databases.
+
+clear
+% Do a single cBathy analysis, returning the bathy structure (which you
+% would normally save somewhere) and displaying the results.  
+stationStr = 'argus02a';
+stackName = 'testStack102210Duck';
+%stationStr = 'aerielle';
+%stackName = 'C:\Users\mpalmsten\Documents\projects\DUCK\UAVData\UAVdemoMovies\demoMovies\demoOutput\1443742140.Thu.Oct.01_23_29_00.GMT.2015.Aerielle.cx.mBW.mat';
+%bathy = analyzeSingleBathyRunAerielleNotCIL(stackName, stationStr);
+bathy = analyzeSingleBathyRunNotCIL(stackName, stationStr);
+plotBathyCollect(bathy)
+
+% Now compare this result with a supplied example CRAB survey from three
+% days prior.
+CRABpn = '19-Oct-2010FRFGridded.mat';
+load(CRABpn)
+figure(1); clf
+subplot(121)
+imagesc(xm,ym,zi); grid on; caxis([-8 1])
+axis xy; xlabel('x (m)'); ylabel('y (m)'); title(['CRAB, ' CRABpn])
+
+% remove results with HErr greater than a threshold and plot cBathy results
+subplot(122)
+h2 = bathy.fCombined.h;
+threshErr = 1.0;
+h2(bathy.fCombined.hErr>threshErr) = nan;
+imagesc(bathy.xm,bathy.ym,-h2); grid on
+caxis([-8 1])
+axis xy; xlabel('x (m)'); ylabel('y (m)'); 
+title(['cBathy, ' datestr(epoch2Matlab(str2num(bathy.epoch)))])
+
+% Finally, try turning on the debug feature and test it using guidance from
+% the user manual.  This is done by setting params.debug.production to 0.
+% You may want to change some of the debug options.  You then simply repeat
+% the analyzeSingleBathyNotCIL commands.%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%
+

--- a/predictCSM.m
+++ b/predictCSM.m
@@ -1,4 +1,4 @@
-function q = predictCSM(kAlphaPhi, xyw)
+function q = predictCSM( kAlphaPhi,xyw)
 % q = predictCSM(kAlphaPhi, xyw)
 %
 % compute complex cross-spectral matrix from wavenumber and direction,

--- a/res.m
+++ b/res.m
@@ -1,0 +1,36 @@
+function dq = res(p, x, yDat)
+% calculate residual for predictCSM.m. Called by LMFnlsq.m.
+%
+% Inputs
+% p     n-vector of intital guess of parameters
+% x     m-vectors or matrix of independent variables (used as arg to func)
+% yDat  m-vectors or matrix of data to be fit by func(x,p)
+%
+% Outputs
+% dq   m-vector of residual
+
+dq = predictCSM(p,x)-yDat;
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%
+

--- a/res2.m
+++ b/res2.m
@@ -1,0 +1,38 @@
+function dq = res2(p, x, yDat)
+% calculate residual for kInvertDepthModel.m. Called by LMFnlsq.m.
+%
+% Inputs
+% p     n-vector of intital guess of parameters (h)
+% x     m-vectors or matrix of independent variables (used as arg to
+% func)(frequency*weight)
+% yDat  m-vectors or matrix of data to be fit by func(x,p)
+%
+% Outputs
+% dq   m-vector of residual
+
+dq = kInvertDepthModel(p,x)- yDat;
+
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%
+

--- a/tstat3.m
+++ b/tstat3.m
@@ -1,0 +1,100 @@
+function pt = tstat3( v, tp, stat )
+% TSTAT3 computes one of three t_statistics: one-sided t-probability, or
+%        two-sided t-probability, or the inverse t-statistic in any single 
+%        call.  It does not take vectors as arguments.  
+% 
+%   INPUT ARGUMENTS: 
+%       v       Degrees-of freedom (integer)
+% 
+%       tp      T-statistic: to produce t-probability
+%                   OR
+%               Probability (alpha): to produce t-statistic
+% 
+%       stat    Desired test — 
+%                   'one'   One-tailed t-probability
+%                   'two'   Two-tailed t-probability
+%                   'inv'   Inverse t-test
+% 
+%   OUTPUT ARGUMENT:
+%       pt      T-probability OR T-statistic, as requested in ‘stat’
+% 
+%   USE:
+%       FIND ONE-TAILED PROBABILITY GIVEN t-STATISTIC & DEGREES-OF-FREEDOM
+%           p = tstat3(v, t, 'one')
+% 
+%       FIND TWO-TAILED PROBABILITY GIVEN t-STATISTIC & DEGREES-OF-FREEDOM
+%           p = tstat3(v, t, 'two')
+% 
+%       FIND ONE-TAILED t-STATISTIC GIVEN PROBABILITY & DEGREES-OF-FREEDOM
+%           t = tstat3(v, p, 'inv')
+%       
+%  
+%  
+% Star Strider — 2016 01 24 — 
+
+
+% % % % T-DISTRIBUTIONS — 
+% Variables: 
+% t: t-statistic
+% v: degrees of freedom
+
+tdist2T = @(t,v) (1-betainc(v/(v+t^2), v/2, 0.5));                              % 2-tailed t-distribution
+tdist1T = @(t,v) 1-(1-tdist2T(t,v))/2;                                          % 1-tailed t-distribution
+
+% This calculates the inverse t-distribution (parameters given the
+%   probability ‘alpha’ and degrees of freedom ‘v’: 
+t_inv = @(alpha,v) fzero(@(tval) (max(alpha,(1-alpha)) - tdist1T(tval,v)), 5);  % T-Statistic Given Probability ‘alpha’ & Degrees-Of-Freedom ‘v’
+
+statcell = {'one' 'two' 'inv'};                                                 % Available Options
+nc = cellfun(@(x)~isempty(x), regexp(statcell, stat));                          % Logical Match Array
+n = find(nc);                                                                   % Convert ‘nc’ To Integer
+
+if (length(v) > 1) || (length(tp) > 1)
+    error('                    —> TSTAT3 does not take vectorised inputs.')
+elseif isempty(n)                                                                   % Error Check ‘if’ Block
+    error('                    —> The third argument must be either ''one'', ''two'', or ''inv''.')
+elseif (n == 3) && ((tp < 0) || (tp > 1))
+    error('                    —> The probability for ''inv'' must be between 0 and 1.')
+elseif (isempty(v) || (v <= 0))
+    error('                    —> The degrees-of-freedom (''v'') must be > 0.')
+end
+
+switch n                                                                        % Calculate Requested Statistics
+    case 1
+        pt = tdist1T(tp, v);
+    case 2
+        pt = tdist2T(tp, v);
+    case 3
+        pt = t_inv(tp, v);
+    otherwise
+        pt = NaN;
+end
+
+
+end
+% ———————————————————————————  END: tstat3.m  ————————————————————————————
+
+% original code was downloaded from Matlab Central 
+%
+%   Copyright (C) 2017  Coastal Imaging Research Network
+%                       and Oregon State University
+
+%    This program is free software: you can redistribute it and/or  
+%    modify it under the terms of the GNU General Public License as 
+%    published by the Free Software Foundation, version 3 of the 
+%    License.
+
+%    This program is distributed in the hope that it will be useful,
+%    but WITHOUT ANY WARRANTY; without even the implied warranty of
+%    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%    GNU General Public License for more details.
+
+%    You should have received a copy of the GNU General Public License
+%    along with this program.  If not, see
+%                                <http://www.gnu.org/licenses/>.
+
+% CIRN: https://coastal-imaging-research-network.github.io/
+% CIL:  http://cil-www.coas.oregonstate.edu
+%
+%key cBathy
+%


### PR DESCRIPTION
I removed dependency on the Matlab Statistics and Machine Learning Toolbox by removing all calls to nlinfit.m, nlparci.m, and tinv.m and replacing with LMFnlsq.m and tstat3.m downloaded from the Matlab File Exchange. cBathy depth results have only very minimal differences with results from the development branch due to a slightly different implementation of the Levenberg-Marquardt curve fitting algorithm.