### PR TITLE
Fix PhaseMap Plot

### DIFF
--- a/plotPhaseTile.m
+++ b/plotPhaseTile.m
@@ -12,22 +12,22 @@ function plotPhaseTile(xy, v, vPred)
 va = angle(v)*180/pi;
 vpa = angle(vPred)*180/pi;
 subplot(221)
-scatter3(xy(:,1), xy(:,2), va, [], va);
+scatter3(xy(:,1), xy(:,2), va, [], va, 'filled');
 view(2); caxis([-180 180]);  colorbar
 xlabel('x (m)'); ylabel('y (m)'); title('Observed phase')
 
 subplot(222)
-scatter3(xy(:,1), xy(:,2), abs(v), [], abs(v));
+scatter3(xy(:,1), xy(:,2), abs(v), [], abs(v), 'filled');
 view(2); colorbar
 xlabel('x (m)'); ylabel('y (m)'); title('Observed magnitude')
 
 subplot(223)
-scatter3(xy(:,1), xy(:,2), vpa, [], vpa);
+scatter3(xy(:,1), xy(:,2), vpa, [], vpa, 'filled');
 view(2); caxis([-180 180]); colorbar
 xlabel('x (m)'); ylabel('y (m)'); title('Predicted phase')
 
 subplot(224)
-scatter3(xy(:,1), xy(:,2), abs(vPred), [], abs(vPred));
+scatter3(xy(:,1), xy(:,2), abs(vPred), [], abs(vPred), 'filled');
 view(2); colorbar
 xlabel('x (m)'); ylabel('y (m)'); title('Predicted magnitude')
 


### PR DESCRIPTION
This branch changes the scatter plot to show filled circles when plotting the phases to visualize waves better, as requested by @RobHolman.

When plotting from the Development branch, the phase plot looks like this:
![devbranchphasemap](https://user-images.githubusercontent.com/6739914/40937180-c4c1fd28-680b-11e8-9f5d-d240b0c7e26e.png)

This fix fills the scatter plot so the new phase plot looks like this:
![fixbranchphasemap](https://user-images.githubusercontent.com/6739914/40937198-d2129460-680b-11e8-8355-2f0b8d9930c1.png)

@mpalmsten @SRHarrison @jstanleyx please test and approve on your end. 
