### PR TITLE
Bug fixes for cBathy demo

### DIFF
--- a/analyzeBathyCollect.m
+++ b/analyzeBathyCollect.m
@@ -52,7 +52,7 @@ if( cBDebug( bathy.params, 'DOSHOWPROGRESS' ))
     title('Analysis Progress'); drawnow;
     hold on
 end
-str = [bathy.sName(16:21) ', ' bathy.sName(36:39) ', ' bathy.sName([23 24 26 27])];
+str = [bathy.sName];
 if cBDebug( bathy.params )
 	hWait = waitbar(0, str);
 end;

--- a/demoKalmanFiltering.m
+++ b/demoKalmanFiltering.m
@@ -1,6 +1,6 @@
 % demo Kalman filter process using a one day set of cBathy results
 
-clear
+
 cBInputPn = '102210cBathys/';     % a simple example day, stored locally
 fns = dir([cBInputPn,'*.mat']);
 

--- a/democBathy.m
+++ b/democBathy.m
@@ -2,7 +2,7 @@
 % results.  It uses a supplied example data set and does not make
 % assumptions about CIL conventions or databases.
 
-clear
+
 % Do a single cBathy analysis, returning the bathy structure (which you
 % would normally save somewhere) and displaying the results.  
 stationStr = 'argus02a';


### PR DESCRIPTION
Small bug fixes performed on the routines analyzeBathyCollect.m, democBathy.m, and demoKalmanFiltering.m. These codes are all used by the cBathy demo in the practicum starter guide (see Support-Routines repo), and were causing the demo to crash. 

The demo station name does not follow typical Argus naming conventions, which was causing analyzeBathyCollect.m to throw an error. This was resolved by allowing the routine to show the full station name over a loading bar.

'clear' commands were removed from the beginning of democBathy.m and demoKalmanFiltering.m. A variable created at the start of the cBathy demo which is needed later in the demo was deleted by these routines. 