### PR TITLE
Bruder s name bug

### DIFF
--- a/analyzeBathyCollect.m
+++ b/analyzeBathyCollect.m
@@ -52,7 +52,11 @@ if( cBDebug( bathy.params, 'DOSHOWPROGRESS' ))
     title('Analysis Progress'); drawnow;
     hold on
 end
-str = [bathy.sName(16:21) ', ' bathy.sName(36:39) ', ' bathy.sName([23 24 26 27])];
+
+
+str = datestr(epoch/24/3600 +datenum(1970,1,1));
+    
+
 if cBDebug( bathy.params )
 	hWait = waitbar(0, str);
 end;

--- a/analyzeBathyCollect.m
+++ b/analyzeBathyCollect.m
@@ -54,11 +54,10 @@ if( cBDebug( bathy.params, 'DOSHOWPROGRESS' ))
 end
 
 
-str = datestr(epoch/24/3600 +datenum(1970,1,1));
     
 
 if cBDebug( bathy.params )
-	hWait = waitbar(0, str);
+	hWait = waitbar(0, ['Cumulative Progress']);
 end;
 
 for xind = 1:length(bathy.xm)


### PR DESCRIPTION
Hi all, 
I have been trying to run the Master democBathy.m and I have been running into the issue that it crashes on 

```
Error in democBathy (line 10)
bathy = analyzeSingleBathyRunNotCIL(stackName, stationStr);

Error in analyzeSingleBathyRunNotCIL (line 33)
bathy = analyzeBathyCollect(xyz, t, data, cam, bathy);

Error in analyzeBathyCollect (line 55)
str = [bathy.sName(16:21) ', ' bathy.sName(36:39) ', ' bathy.sName([23 24 26 27])];
```


It seems it is trying to pull a string from a traditional mBW file name. It breaks on my computer for the development branch as well. It does not break  on RobUpdates061119. In that branch it just comments out line 55 in analyzeBathyCollect and that seems to make it work.

So I guess it can be one of two issues....
1) Something is going on with Rob's and my computers that does not allow the code to work.
2) This was an issue we kept fixing on site of the bootcamp and just never implemented into master/development.

I think it is (2). The variable 'str' in line 55 is just used for progress bar title and not passed along to anything else. So I deleted 'str' and just changed the title to be 'Cumulative Progress.' 

This is not really a big deal however it would be nice for it to work for users who have not attended the bootcamp. Also...I wanted to practice my githubbing ;)